### PR TITLE
upgrade electron to 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -996,9 +996,9 @@
       "dev": true
     },
     "electron": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.7.tgz",
-      "integrity": "sha512-MRrDE6mrp+ZrIBpZM27pxbO2yEDKYfkmc6Ll79BtedMNEZsY4+oblupeDJL6RM6meUIp82KMo63W7fP65Tb89Q==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.8.tgz",
+      "integrity": "sha512-pbeGFbwijb5V3Xy/KMcwIp59eA9igg2br+7EHbbwQoa3HRDF5JjTrciX7OiscCA52+ze2n4q38S4lXPqRitgIA==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     }
   },
   "devDependencies": {
-    "electron": "2.0.7",
+    "electron": "^2.0.8",
     "electron-builder": "20.28.1",
     "electron-reload": "^1.2.5"
   },


### PR DESCRIPTION
Resolves [CVE-2018-15685](https://electronjs.org/blog/web-preferences-fix). The tray app does not use iframes much less run user-supplied code in an iframe, so it does not have this vulnerability.