### PR TITLE
Supply dmg.title to set the volume name

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     },
     "appImage": {
       "systemIntegration": "doNotAsk"
+    },
+    "dmg": {
+      "title": "chef-workstation"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
This simplifies the auto-install story for mac.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>