### PR TITLE
Omnibus inclusion support: split build targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build": "build --linux --mac --win",
-    "release": "build --linux --mac --win -p always"
+    "build-all": "build --win --mac --linux --publish never",
+    "build-mac": "build --mac --publish never",
+    "build-linux": "build --linux --publish never",
+    "build-win": "build --win --publish never"
   },
   "build": {
     "appId": "sh.chef.chef-workstation",
     "electronUpdaterCompatibility": ">= 2.16",
     "mac": {
+      "target": ["zip" ],
       "category": "public.app-category.developer-tools",
       "icon": "assets/images/logo.png",
       "extendInfo": {
@@ -27,10 +30,7 @@
       }
     },
     "win": {
-      "target": [
-        "msi",
-        "nsis"
-      ],
+      "target": [ "zip" ],
       "icon": "assets/images/logo.ico"
     },
     "publish": [
@@ -39,11 +39,7 @@
       }
     ],
     "linux": {
-      "target": [
-        "deb",
-        "rpm",
-        "appImage"
-      ]
+      "target": [ "dir" ]
     },
     "appImage": {
       "systemIntegration": "doNotAsk"


### PR DESCRIPTION
This splits out the mac/linux/win build targets, and removes
'publish' because we will not be publishing this outside of the
Chef Workstation package for the time being.

It also changes the output format to zip for Mac and Windows, and
'directory' for linux.  Linux differs to prevent build-time issues
with incorrect GLIBC version when building the electron app on RHEL6.

The chef-workstation omnibus build will run the electron application
build and include the artifacts in the chef-workstation package.