### PR TITLE
Switch Windows build to use directory mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
     "win": {
       "target": [
-        "zip"
+        "dir"
       ],
       "icon": "assets/images/logo.ico"
     },


### PR DESCRIPTION
This is in support of modifying the Windows install package
to include the unpacked App distribution.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>